### PR TITLE
Update Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,8 @@ gunicorn = "*"
 cloudinary = "*"
 flask-admin = "*"
 typing-extensions = "*"
+flask-jwt-extended = "==4.6.0"
+wtforms = "==3.1.2"
 
 [requires]
 python_version = "3.10"


### PR DESCRIPTION
Soluciona problema ocacionado por la instalación de flask-jwt-extended

```
Atriburte Error
AttributeError: 'tuple' object has no attribute 'items'
```

Se configuran las versiones de los package:

```

flask-jwt-extended = "==4.6.0"
wtforms = "==3.1.2"
```